### PR TITLE
add custom decimal precision to splittable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## splittable 0.0.5 (Feb 02, 2021)
+
+* Add precision parameter to division and normilize methods
+
+  *Ítalo Matos*
+
 ## splittable 0.0.4 (Jan 29, 2021)
 
 * Fix publish_release job

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    splittable (0.0.4)
+    splittable (0.0.5)
 
 GEM
   remote: https://rubygems.org/

--- a/README.md
+++ b/README.md
@@ -36,6 +36,17 @@ Result: the total truncated value was divided by the number of plots informed an
 ```ruby
 => [0.5e-1, 0.3e-1, 0.3e-1] # => [0.05, 0.03, 0.03]
 ```
+Default precision is 2 decimal places, but, you can customize this with precision parameter: 
+
+``` ruby
+Splittable.division(value: 10, quantity: 3, precision: 3)
+```
+
+Result: 
+```ruby
+=> [0.3334e1, 0.3333e1, 0.3333e1] # => [0.334, 0.333, 0.333]
+```
+
 
 Using `normalize` method:
 
@@ -47,6 +58,16 @@ Result: all values are truncated and them the difference is attributed in the fi
 
 ```ruby
 => [0.3524e2, 0.2143e2, 0.4333e2] # => [35.24, 21.43, 43.33]
+```
+
+In this method, you have the same optional precision parameter: 
+```ruby
+Splittable.normalize(value: 100, installments: [33.33333333, 33.33333333, 33.33333333], precision: 3)
+```
+
+Result: 
+```ruby
+=> [0.33334e2, 0.33333e2, 0.33333e2] # => [33.334, 33.333, 33.333]
 ```
 
 ## Development

--- a/lib/splittable.rb
+++ b/lib/splittable.rb
@@ -9,14 +9,14 @@ module Splittable
   class << self
     # receive total value and to quantity installments are required to equal division
     # just the first installment will receive the difference cents
-    def division(value:, quantity:)
-      Splittable::Division.new(value: value, quantity: quantity).call
+    def division(value:, quantity:, precision: 2)
+      Splittable::Division.new(value: value, quantity: quantity, precision: precision).call
     end
 
     # receive total value and specific value of installments are required to specific division
     # just the first installment will receive the difference cents
-    def normalize(value:, installments:)
-      Splittable::Normalize.new(value: value, installments: installments).call
+    def normalize(value:, installments:, precision: 2)
+      Splittable::Normalize.new(value: value, installments: installments, precision: precision).call
     end
   end
 end

--- a/lib/splittable/division.rb
+++ b/lib/splittable/division.rb
@@ -1,15 +1,16 @@
 # frozen_string_literal: true
 
 class Splittable::Division
-  def initialize(value:, quantity:)
-    @value = BigDecimal(value, 15).truncate(2)
+  def initialize(value:, quantity:, precision:)
+    @precision = precision
+    @value = BigDecimal(value, 15).truncate(precision)
     @quantity = BigDecimal(quantity.to_i, 15)
 
     check_quantity_as_positive_value!
   end
 
   def call
-    partial_value = (value / quantity).truncate(2)
+    partial_value = (value / quantity).truncate(precision)
     installments = [partial_value] * quantity
     installments[0] += value - installments.sum.to_d
 
@@ -18,7 +19,7 @@ class Splittable::Division
 
   private
 
-  attr_reader :value, :quantity
+  attr_reader :value, :quantity, :precision
 
   def check_quantity_as_positive_value!
     return if quantity.positive?

--- a/lib/splittable/division.rb
+++ b/lib/splittable/division.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class Splittable::Division
-  def initialize(value:, quantity:, precision:)
+  def initialize(value:, quantity:, precision: 2)
     @precision = precision
     @value = BigDecimal(value, 15).truncate(precision)
     @quantity = BigDecimal(quantity.to_i, 15)

--- a/lib/splittable/normalize.rb
+++ b/lib/splittable/normalize.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class Splittable::Normalize
-  def initialize(value:, installments:, precision:)
+  def initialize(value:, installments:, precision: 2)
     @value = BigDecimal(value, 15).truncate(precision)
     @installments = installments.map { |installment| BigDecimal(installment.round(precision), 15) }
   end

--- a/lib/splittable/normalize.rb
+++ b/lib/splittable/normalize.rb
@@ -1,9 +1,9 @@
 # frozen_string_literal: true
 
 class Splittable::Normalize
-  def initialize(value:, installments:)
-    @value = BigDecimal(value, 15).truncate(2)
-    @installments = installments.map { |installment| BigDecimal(installment.round(2), 15) }
+  def initialize(value:, installments:, precision:)
+    @value = BigDecimal(value, 15).truncate(precision)
+    @installments = installments.map { |installment| BigDecimal(installment.round(precision), 15) }
   end
 
   def call

--- a/lib/splittable/version.rb
+++ b/lib/splittable/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Splittable
-  VERSION = '0.0.4'
+  VERSION = '0.0.5'
 end

--- a/spec/splittable_spec.rb
+++ b/spec/splittable_spec.rb
@@ -4,23 +4,25 @@ require 'spec_helper'
 
 RSpec.describe Splittable do
   describe '.division' do
-    subject(:division) { described_class.division(value: value, quantity: quantity) }
+    subject(:division) { described_class.division(value: value, quantity: quantity, precision: precision) }
 
     [
-      # input: [value, quantity]
-      { input: [0.1, 3],     result: [0.04, 0.03, 0.03], result_sum: 0.1 },
-      { input: [0.11888, 3], result: [0.05, 0.03, 0.03], result_sum: 0.11 },
-      { input: [0.18, 5],    result: [0.06, 0.03, 0.03, 0.03, 0.03], result_sum: 0.18 },
-      { input: [0.04, 5],    result: [0.04, 0.0, 0.0, 0.0, 0.0], result_sum: 0.04 },
-      { input: [0.07, 5],    result: [0.03, 0.01, 0.01, 0.01, 0.01], result_sum: 0.07 },
-      { input: [100, 12],    result: [8.37, 8.33, 8.33, 8.33, 8.33, 8.33, 8.33, 8.33, 8.33, 8.33, 8.33, 8.33],
+      # input: [value, quantity, precision]
+      { input: [0.1, 3, 2],     result: [0.04, 0.03, 0.03], result_sum: 0.1 },
+      { input: [0.11888, 3, 2], result: [0.05, 0.03, 0.03], result_sum: 0.11 },
+      { input: [0.18, 5, 2],    result: [0.06, 0.03, 0.03, 0.03, 0.03], result_sum: 0.18 },
+      { input: [0.04, 5, 2],    result: [0.04, 0.0, 0.0, 0.0, 0.0], result_sum: 0.04 },
+      { input: [0.07, 5, 2],    result: [0.03, 0.01, 0.01, 0.01, 0.01], result_sum: 0.07 },
+      { input: [100, 12, 2],    result: [8.37, 8.33, 8.33, 8.33, 8.33, 8.33, 8.33, 8.33, 8.33, 8.33, 8.33, 8.33],
         result_sum: 100 },
-      { input: [10, 2],      result: [5, 5], result_sum: 10 },
-      { input: [294.03, 6],  result: [49.03, 49, 49, 49, 49, 49], result_sum: 294.03 }
+      { input: [10, 2, 2],      result: [5, 5], result_sum: 10 },
+      { input: [294.03, 6, 2],  result: [49.03, 49, 49, 49, 49, 49], result_sum: 294.03 },
+      { input: [10, 3, 3], result: [3.334, 3.333, 3.333], result_sum: 10 }
     ].each do |example|
       context "when input is #{example[:input]}" do
-        let(:value) { example[:input].first }
-        let(:quantity) { example[:input].last }
+        let(:value) { example[:input][0] }
+        let(:quantity) { example[:input][1] }
+        let(:precision) { example[:input][2] }
         let(:expected_result) { example[:result].map { |r| BigDecimal(r, 15) } }
 
         it { expect(division).to eq expected_result }
@@ -32,6 +34,7 @@ RSpec.describe Splittable do
     context 'when quantity is zero' do
       let(:value) { 1 }
       let(:quantity) { 0 }
+      let(:precision) { 2 }
       let(:error_message) { 'quantity should be positive' }
 
       it { expect { division }.to raise_error(ArgumentError, error_message) }
@@ -40,18 +43,20 @@ RSpec.describe Splittable do
 
   describe '.normalize' do
     [
-      { value: 1000,    installments: [35.987, 964.013],         result: [35.99, 964.01] },
-      { value: 1000,    installments: [35.987, 964.019],         result: [35.98, 964.02] },
-      { value: 1000,    installments: [35.98, 964.01],           result: [35.99, 964.01] },
-      { value: 100,     installments: [33.33, 33.333, 33.33333], result: [33.34, 33.33, 33.33] },
-      { value: 100.003, installments: [33.33, 33.333, 33.33333], result: [33.34, 33.33, 33.33] },
+      { value: 1000,    installments: [35.987, 964.013],         result: [35.99, 964.01], precision: 2 },
+      { value: 1000,    installments: [35.987, 964.019],         result: [35.98, 964.02], precision: 2 },
+      { value: 1000,    installments: [35.98, 964.01],           result: [35.99, 964.01], precision: 2 },
+      { value: 100,     installments: [33.33, 33.333, 33.33333], result: [33.34, 33.33, 33.33], precision: 2 },
+      { value: 100.003, installments: [33.33, 33.333, 33.33333], result: [33.34, 33.33, 33.33], precision: 2 },
       { value: 294.03,  installments: [49.005, 49.005, 49.005, 49.005, 49.005, 49.005],
-        result: [48.98, 49.01, 49.01, 49.01, 49.01, 49.01] },
+        result: [48.98, 49.01, 49.01, 49.01, 49.01, 49.01], precision: 2 },
       { value: 1170,    installments: [235.224, 235.224, 229.11000000000027, 235.21999999999974, 235.224],
-        result: [235.23, 235.22, 229.11, 235.22, 235.22] }
+        result: [235.23, 235.22, 229.11, 235.22, 235.22], precision: 2 },
+      { value: 10, installments: [3.33333, 3.333333, 3.3333333], result: [3.334, 3.333, 3.333], precision: 3 }
     ].each do |example|
       it "installments like #{example[:installments]} should be normalized to #{example[:result]}" do
-        normalized = described_class.normalize(value: example[:value], installments: example[:installments])
+        normalized = described_class.normalize(value: example[:value], installments: example[:installments],
+                                               precision: example[:precision])
         expect(normalized).to eq(example[:result])
       end
     end


### PR DESCRIPTION
## Description

This PR is reference this issue: https://github.com/Pagnet/splittable/issues/5

Has goal to have a flexible decimal precision.

Fixes # (issue)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

bin/console
```
Splittable.division(value: 10, quantity: 3, precision: 3).map(&:to_f)
Result: 3.334, 3.333, 3.333
```

## Screenshots (if appropriate):

## Checklist:

- [X] I have read the [CONTRIBUTING](../CONTRIBUTING.md) document
- [X] I have performed a self-review of my own code
- [X] My changes generate no new warnings
- [X] My changes work in Chrome, Edge, and Firefox
- [] I have made corresponding changes to the documentation (if appropriate)
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] All new and existing tests passed